### PR TITLE
fix: could not find a declaration file for module error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-quickstart/ecs-consul-mesh-extension",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "description": "An Amazon ECS service extension for Consul",
   "scripts": {
     "build": "tsc",
@@ -32,7 +32,8 @@
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
-  "main": "jest.config.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "directories": {
     "lib": "lib",
     "test": "test"


### PR DESCRIPTION
Add fix for could not find a declaration file for module error. 
Changed main and types param to have following values
 "main": "dist/index.js",
 "types": "dist/index.d.ts",