### PR TITLE
Fix: Change side-cars default images

### DIFF
--- a/lib/consul-mesh-extension.ts
+++ b/lib/consul-mesh-extension.ts
@@ -14,9 +14,9 @@ import * as secretsmanager from '@aws-cdk/aws-secretsmanager'
 /**
  * envoy, consul and consul-ecs container images
  */
-const CONSUL_CONTAINER_IMAGE = 'hashicorp/consul:1.9.5';
-const CONSUL_ECS_CONTAINER_IMAGE = 'hashicorpdev/consul-ecs:latest';
-const ENVOY_CONTAINER_IMAGE = 'envoyproxy/envoy-alpine:v1.16.2';
+const CONSUL_CONTAINER_IMAGE = 'hashicorp/consul:1.10.4';
+const CONSUL_ECS_CONTAINER_IMAGE = 'hashicorp/consul-ecs:0.2.0';
+const ENVOY_CONTAINER_IMAGE = 'envoyproxy/envoy-alpine:v1.18.4';
 const maxSecurityGroupLimit = 5;
 let environment: {  //environment variable is used to hold the environment details from app container
     [key: string]: string;

--- a/test/consul-extension.test.ts
+++ b/test/consul-extension.test.ts
@@ -175,7 +175,7 @@ test('Test extension with default params', () => {
           "-ec"
         ],
         "Essential": false,
-        "Image": "hashicorp/consul:1.9.5",
+        "Image": "hashicorp/consul:1.10.4",
         "LogConfiguration": {
           "LogDriver": "awslogs",
           "Options": {
@@ -231,7 +231,7 @@ test('Test extension with default params', () => {
           "-service-name=greeter"
         ],
         "Essential": false,
-        "Image": "hashicorpdev/consul-ecs:latest",
+        "Image": "hashicorp/consul-ecs:0.2.0",
         "LogConfiguration": {
           "LogDriver": "awslogs",
           "Options": {
@@ -289,7 +289,7 @@ test('Test extension with default params', () => {
           "Retries": 3,
           "Timeout": 5
         },
-        "Image": "envoyproxy/envoy-alpine:v1.16.2",
+        "Image": "envoyproxy/envoy-alpine:v1.18.4",
         "LogConfiguration": {
           "LogDriver": "awslogs",
           "Options": {
@@ -426,7 +426,7 @@ test('Test extension with default params', () => {
           "-ec"
         ],
         "Essential": false,
-        "Image": "hashicorp/consul:1.9.5",
+        "Image": "hashicorp/consul:1.10.4",
         "LogConfiguration": {
           "LogDriver": "awslogs",
           "Options": {
@@ -482,7 +482,7 @@ test('Test extension with default params', () => {
           "-service-name=name"
         ],
         "Essential": false,
-        "Image": "hashicorpdev/consul-ecs:latest",
+        "Image": "hashicorp/consul-ecs:0.2.0",
         "LogConfiguration": {
           "LogDriver": "awslogs",
           "Options": {
@@ -540,7 +540,7 @@ test('Test extension with default params', () => {
           "Retries": 3,
           "Timeout": 5
         },
-        "Image": "envoyproxy/envoy-alpine:v1.16.2",
+        "Image": "envoyproxy/envoy-alpine:v1.18.4",
         "LogConfiguration": {
           "LogDriver": "awslogs",
           "Options": {


### PR DESCRIPTION
This PR will change the default images for consul, consul-ecs and envoy proxy as per the latest from Hashicorp.