### PR TITLE
Fix: Remove port param from ECSConsulMeshExtension Props

### DIFF
--- a/test/consul-extension.test.ts
+++ b/test/consul-extension.test.ts
@@ -56,7 +56,6 @@ test('Test extension with default params', () => {
   nameDescription.add(new ECSConsulMeshExtension({
     retryJoin: new RetryJoin({ region: "us-west-2", tagName: "Name", tagValue: "test-consul-server" }),
     consulServerSecurityGroup: consulSecurityGroup,
-    port: 3000,
     consulClientSecurityGroup,
     tls: true,
     consulCACert: TLSSecret,
@@ -81,7 +80,6 @@ test('Test extension with default params', () => {
   greeterDescription.add(new ECSConsulMeshExtension({
     retryJoin: new RetryJoin({ region: "us-west-2", tagName: "Name", tagValue: "test-consul-server" }),
     consulServerSecurityGroup: consulSecurityGroup,
-    port: 3000,
     consulClientSecurityGroup,
     tls: true,
     consulCACert: TLSSecret,
@@ -741,7 +739,6 @@ test('Test extension with custom params', () => {
   nameDescription.add(new ECSConsulMeshExtension({
     retryJoin: new RetryJoin({ region: "us-west-2", tagName: "Name", tagValue: "test-consul-server" }),
     consulServerSecurityGroup: consulSecurityGroup,
-    port: 3000,
     consulClientImage: "myCustomConsulClientImage:1.0",
     consulEcsImage: "myCustomConsulEcsImage:1.0",
     envoyProxyImage: "myCustomEnvoyImage:1.0",
@@ -769,7 +766,6 @@ test('Test extension with custom params', () => {
   greeterDescription.add(new ECSConsulMeshExtension({
     retryJoin: new RetryJoin({ region: "us-west-2", tagName: "Name", tagValue: "test-consul-server" }),
     consulServerSecurityGroup: consulSecurityGroup,
-    port: 3000,
     consulClientImage: "myCustomConsulClientImage:1.0",
     consulEcsImage: "myCustomConsulEcsImage:1.0",
     envoyProxyImage: "myCustomEnvoyImage:1.0",
@@ -1420,7 +1416,6 @@ const development = new Environment(stack, 'development');
   nameDescription.add(new ECSConsulMeshExtension({
     retryJoin: new RetryJoin({ region: "us-west-2", tagName: "Name", tagValue: "test-consul-server" }),
     consulServerSecurityGroup: consulSecurityGroup,
-    port: 3000,
     consulClientImage: "myCustomConsulClientImage:1.0",
     consulEcsImage: "myCustomConsulEcsImage:1.0",
     envoyProxyImage: "myCustomEnvoyImage:1.0",
@@ -1445,7 +1440,6 @@ const development = new Environment(stack, 'development');
   greeterDescription.add(new ECSConsulMeshExtension({
     retryJoin: new RetryJoin({ region: "us-west-2", tagName: "Name", tagValue: "test-consul-server" }),
     consulServerSecurityGroup: consulSecurityGroup,
-    port: 3000,
     consulClientImage: "myCustomConsulClientImage:1.0",
     consulEcsImage: "myCustomConsulEcsImage:1.0",
     envoyProxyImage: "myCustomEnvoyImage:1.0",


### PR DESCRIPTION
This PR will remove port param from the ECSConsulMeshExtension Props and replace it with the traffic port from the application container. This will reduce the redundancy of the same port usage with the two different name in ECS and Consul world.