### PR TITLE
Fix: Add ulimits to envoy proxy

### DIFF
--- a/lib/consul-mesh-extension.ts
+++ b/lib/consul-mesh-extension.ts
@@ -337,6 +337,17 @@ export class ECSConsulMeshExtension extends ServiceExtension {
             essential: false
         });
 
+        this.container.addUlimits(
+            {
+                name: ecs.UlimitName.NOFILE,
+                // Note: 2^20 (1048576) is the maximum.
+                // Going higher would need sysctl settings: https://github.com/aws/containers-roadmap/issues/460.
+                // AWS API will accept invalid values, and you will see a CannotStartContainerError at runtime.
+                softLimit: 1048576,
+                hardLimit: 1048576
+            }
+        );
+
         this.container.addContainerDependencies(
             {
                 container: this.meshInit,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-quickstart/ecs-consul-mesh-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An Amazon ECS service extension for Consul",
   "scripts": {
     "build": "tsc",

--- a/test/consul-extension.test.ts
+++ b/test/consul-extension.test.ts
@@ -314,6 +314,13 @@ test('Test extension with default params', () => {
             "ContainerPort": 20000,
             "Protocol": "tcp"
           }
+        ],
+        "Ulimits": [
+          {
+            "HardLimit": 1048576,
+            "Name": "nofile",
+            "SoftLimit": 1048576
+          }
         ]
       }
     ],
@@ -564,6 +571,13 @@ test('Test extension with default params', () => {
           {
             "ContainerPort": 20000,
             "Protocol": "tcp"
+          }
+        ],
+        "Ulimits": [
+          {
+            "HardLimit": 1048576,
+            "Name": "nofile",
+            "SoftLimit": 1048576
           }
         ]
       }
@@ -1003,6 +1017,13 @@ test('Test extension with custom params', () => {
             "ContainerPort": 20000,
             "Protocol": "tcp"
           }
+        ],
+        "Ulimits": [
+          {
+            "HardLimit": 1048576,
+            "Name": "nofile",
+            "SoftLimit": 1048576
+          }
         ]
       }
     ],
@@ -1252,6 +1273,13 @@ test('Test extension with custom params', () => {
           {
             "ContainerPort": 20000,
             "Protocol": "tcp"
+          }
+        ],
+        "Ulimits": [
+          {
+            "HardLimit": 1048576,
+            "Name": "nofile",
+            "SoftLimit": 1048576
           }
         ]
       }


### PR DESCRIPTION
This PR will add ulimits to the envot proxy so that it will not segfault. 