### PR TITLE
Remove port param from consul props and fix tag param value

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ import { ECSConsulMeshExtension, RetryJoin } from '@aws-quickstart/ecs-consul-me
 
 const nameDescription = new ServiceDescription();
 nameDescription.add(new ECSConsulMeshExtension({      
-      retryJoin: new RetryJoin({ region: '$AWS_REGION', tagName: 'Name', tagValue: 'test-consul-server' }),
-      port: 3000,
+      retryJoin: new RetryJoin({ region: '$AWS_REGION', tagName: '$TAG_NAME', tagValue: '$TAG_VALUE' }),
       consulClientSecurityGroup: consulClientSecurityGroup,
       consulServerSecurityGroup: consulServerSecurityGroup,
       consulCACert: agentCASecret,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-quickstart/ecs-consul-mesh-extension",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "An Amazon ECS service extension for Consul",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
This PR will remove the `port` parameter from the ECS consul mesh props. And also fixed the values of the `tagName` and `tagValue` parameters. 