### PR TITLE
Fix: Remove root user permission from consul-ecs-mesh-init container

### DIFF
--- a/lib/consul-mesh-extension.ts
+++ b/lib/consul-mesh-extension.ts
@@ -301,8 +301,7 @@ export class ECSConsulMeshExtension extends ServiceExtension {
                 "-upstreams=" + this.buildUpstreamString,
                 "-service-name=" + this.serviceDiscoveryName],
             logging: new ecs.AwsLogDriver({ streamPrefix: 'consul-ecs-mesh-init' }),
-            essential: false,
-            user: "root" // TODO: check if this permission is required
+            essential: false
         });
 
         this.meshInit.addMountPoints({

--- a/test/consul-extension.test.ts
+++ b/test/consul-extension.test.ts
@@ -255,8 +255,7 @@ test('Test extension with default params', () => {
             "SourceVolume": "consul_binary"
           }
         ],
-        "Name": "consul-ecs-mesh-init",
-        "User": "root"
+        "Name": "consul-ecs-mesh-init"
       },
       {
         "Command": [
@@ -513,8 +512,7 @@ test('Test extension with default params', () => {
             "SourceVolume": "consul_binary"
           }
         ],
-        "Name": "consul-ecs-mesh-init",
-        "User": "root"
+        "Name": "consul-ecs-mesh-init"
       },
       {
         "Command": [
@@ -958,8 +956,7 @@ test('Test extension with custom params', () => {
             "SourceVolume": "consul_binary"
           }
         ],
-        "Name": "consul-ecs-mesh-init",
-        "User": "root"
+        "Name": "consul-ecs-mesh-init"
       },
       {
         "Command": [
@@ -1215,8 +1212,7 @@ test('Test extension with custom params', () => {
             "SourceVolume": "consul_binary"
           }
         ],
-        "Name": "consul-ecs-mesh-init",
-        "User": "root"
+        "Name": "consul-ecs-mesh-init"
       },
       {
         "Command": [


### PR DESCRIPTION
This PR will remove root user permission from consul-ecs-mesh-init container. 