### PR TITLE
Add Health Checks for Consul ECS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-quickstart/ecs-consul-mesh-extension",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An Amazon ECS service extension for Consul",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
This PR adds the Consul ECS health checks to the application container. Customers can either add Consul Native Health Checks by providing value to `consulChecks` or ECS Health Checks by providing values to `healthCheck` parameter in ECSConsulMeshExtension.

