### PR TITLE
Optional application entrypoint override

### DIFF
--- a/lib/consul-mesh-extension.ts
+++ b/lib/consul-mesh-extension.ts
@@ -318,6 +318,12 @@ export class ECSConsulMeshExtension extends ServiceExtension {
             throw new Error(`Cannot find service-container`);
         }
 
+        serviceContainer.container?.addMountPoints({
+            containerPath: "/consul/data",
+            sourceVolume: "consul-data",
+            readOnly: true
+        });
+
         new Policy(this.scope, `task-role-${this.parentService.id}`, {
             roles: [taskDefinition.taskRole],
             statements: [

--- a/test/consul-extension.test.ts
+++ b/test/consul-extension.test.ts
@@ -67,7 +67,9 @@ test('Test extension with default params', () => {
       interval: cdk.Duration.seconds(30),
       retries: 3,
       timeout: cdk.Duration.seconds(5),
-    }
+    },
+    applicationShutdownDelaySeconds: 10,
+        command: ["node", "index.js"]
   }));
 
   const nameService = new Service(stack, 'name', {
@@ -101,7 +103,9 @@ test('Test extension with default params', () => {
         timeout  : "10s",
         interval : "2s",
       }
-    ]
+    ],
+    applicationShutdownDelaySeconds: 10,
+    command: ["node", "index.js"]
   }));
 
   const greeterService = new Service(stack, 'greeter', {
@@ -148,6 +152,16 @@ test('Test extension with default params', () => {
             "Name": "nofile",
             "SoftLimit": 1024000
           }
+        ],
+        "Command": [
+          "node",
+          "index.js"
+        ],
+        "EntryPoint": [
+          "/consul/data/consul-ecs",
+          "app-entrypoint",
+          "-shutdown-delay",
+          "10s"
         ]
       },
       {
@@ -416,6 +430,16 @@ test('Test extension with default params', () => {
             "Name": "nofile",
             "SoftLimit": 1024000
           }
+        ],
+        "Command": [
+          "node",
+          "index.js"
+        ],
+        "EntryPoint": [
+          "/consul/data/consul-ecs",
+          "app-entrypoint",
+          "-shutdown-delay",
+          "10s"
         ]
       },
       {

--- a/test/consul-extension.test.ts
+++ b/test/consul-extension.test.ts
@@ -139,6 +139,13 @@ test('Test extension with default params', () => {
         "Essential": true,
         "Image": "nathanpeck/greeter",
         "Memory": 2048,
+        "MountPoints": [
+          {
+            "ContainerPath": "/consul/data",
+            "ReadOnly": true,
+            "SourceVolume": "consul-data"
+          }
+        ],
         "Name": "app",
         "PortMappings": [
           {
@@ -417,6 +424,13 @@ test('Test extension with default params', () => {
         },
         "Image": "nathanpeck/name",
         "Memory": 2048,
+        "MountPoints": [
+          {
+            "ContainerPath": "/consul/data",
+            "ReadOnly": true,
+            "SourceVolume": "consul-data"
+          }
+        ],
         "Name": "app",
         "PortMappings": [
           {
@@ -908,6 +922,13 @@ test('Test extension with custom params', () => {
         "Essential": true,
         "Image": "nathanpeck/greeter",
         "Memory": 2048,
+        "MountPoints": [
+          {
+            "ContainerPath": "/consul/data",
+            "ReadOnly": true,
+            "SourceVolume": "consul-data"
+          }
+        ],
         "Name": "app",
         "PortMappings": [
           {
@@ -1166,6 +1187,13 @@ test('Test extension with custom params', () => {
         "Essential": true,
         "Image": "nathanpeck/name",
         "Memory": 2048,
+        "MountPoints": [
+          {
+            "ContainerPath": "/consul/data",
+            "ReadOnly": true,
+            "SourceVolume": "consul-data"
+          }
+        ],
         "Name": "app",
         "PortMappings": [
           {


### PR DESCRIPTION
Allow users an easy way to override the application entrypoint for better graceful shutdown.

Add a variable applicationShutdownDelaySeconds. When provided, a custom entrypoint is used for the application containers, which will delay the TERM signal for a number of seconds.
The option is ignored for any container definition which has the entryPoint field set.